### PR TITLE
Improve variable name parsing for assignments.

### DIFF
--- a/nix-repl.cc
+++ b/nix-repl.cc
@@ -250,7 +250,8 @@ static int runProgram(const string & program, const Strings & args)
 
 bool isVarName(const string & s)
 {
-    // FIXME: not quite correct.
+    if (s.size() > 0 && (s[0] == '-' || s[0] == '\''))
+        return false;
     for (auto & i : s)
         if (!((i >= 'a' && i <= 'z') ||
               (i >= 'A' && i <= 'Z') ||

--- a/nix-repl.cc
+++ b/nix-repl.cc
@@ -255,7 +255,7 @@ bool isVarName(const string & s)
         if (!((i >= 'a' && i <= 'z') ||
               (i >= 'A' && i <= 'Z') ||
               (i >= '0' && i <= '9') ||
-              i == '_' || i == '\''))
+              i == '_' || i == '-' || i == '\''))
             return false;
     return true;
 }

--- a/nix-repl.cc
+++ b/nix-repl.cc
@@ -250,8 +250,9 @@ static int runProgram(const string & program, const Strings & args)
 
 bool isVarName(const string & s)
 {
-    if (s.size() > 0 && (s[0] == '-' || s[0] == '\''))
-        return false;
+    if (s.size() == 0) return false;
+    char c = s[0];
+    if ((c >= '0' && c <= '9') || c == '-' || c == '\'') return false;
     for (auto & i : s)
         if (!((i >= 'a' && i <= 'z') ||
               (i >= 'A' && i <= 'Z') ||


### PR DESCRIPTION
### Before

```
Welcome to Nix version 1.11pre4379_786046c. Type :? for help.

nix-repl> foo-bar = 2
error: syntax error, unexpected '=', expecting $end, at (string):1:9

nix-repl> foo-bar
error: undefined variable ‘foo-bar’ at (string):1:1
```

### After

```
Welcome to Nix version 1.11pre4379_786046c. Type :? for help.

nix-repl> foo-bar = 2

nix-repl> foo-bar
2
```

This also prevents detecting empty strings and strings beginning with numbers, `-`, or `'` as variable names. As far as I can tell, this makes the assignment parsing fairly robust. Let me know if it's still not quite correct.

Other examples which used to be silently accepted but now properly error out: `= 2`, `' = 2`, `'a = 2`, `0a = 2`.