### PR TITLE
Add :i command to install a derivation to the current profile.

### DIFF
--- a/nix-repl.cc
+++ b/nix-repl.cc
@@ -19,9 +19,6 @@ using namespace std;
 using namespace nix;
 
 
-string programId = "nix-repl";
-
-
 struct NixRepl
 {
     string curDir;

--- a/nix-repl.cc
+++ b/nix-repl.cc
@@ -281,6 +281,7 @@ bool NixRepl::processLine(string line)
              << "  <x> = <expr>  Bind expression to variable\n"
              << "  :a <expr>     Add attributes from resulting set to scope\n"
              << "  :b <expr>     Build derivation\n"
+             << "  :i <expr>     Build derivation, then install result into current profile\n"
              << "  :l <path>     Load Nix expression and add it to scope\n"
              << "  :p <expr>     Evaluate and print expression recursively\n"
              << "  :q            Exit nix-repl\n"
@@ -311,7 +312,7 @@ bool NixRepl::processLine(string line)
         std::cout << showType(v) << std::endl;
     }
 
-    else if (command == ":b" || command == ":s") {
+    else if (command == ":b" || command == ":i" || command == ":s") {
         Value v;
         evalString(arg, v);
         DrvInfo drvInfo(state);
@@ -331,8 +332,11 @@ bool NixRepl::processLine(string line)
                 for (auto & i : drv.outputs)
                     std::cout << format("  %1% -> %2%") % i.first % i.second.path << std::endl;
             }
-        } else
+        } else if (command == ":i") {
+            runProgram("nix-env", Strings{"-i", drvPath});
+        } else {
             runProgram("nix-shell", Strings{drvPath});
+        }
     }
 
     else if (command == ":p" || command == ":print") {

--- a/nix-repl.cc
+++ b/nix-repl.cc
@@ -316,7 +316,7 @@ bool NixRepl::processLine(string line)
         evalString(arg, v);
         DrvInfo drvInfo(state);
         if (!getDerivation(state, v, drvInfo, false))
-            throw Error("expression does not evaluation to a derivation, so I can't build it");
+            throw Error("expression does not evaluate to a derivation, so I can't build it");
         Path drvPath = drvInfo.queryDrvPath();
         if (drvPath == "" || !store->isValidPath(drvPath))
             throw Error("expression did not evaluate to a valid derivation");


### PR DESCRIPTION
Fixes #15.

It works by running `nix-env -i <derivation path>`. You can see it in action [here](https://usercontent.irccloud-cdn.com/file/yVeK7MdE/Screenshot%202016-02-15%20at%2011.19.36%20PM.png) with a silly inline derivation. More commonly, a user would load `<nixpkgs>` and then `:i packageName`.

I also included a couple of unrelated cleanup commits.