### PR TITLE
Open the store before constructing EvalState to fix a segfault.

### DIFF
--- a/nix-repl.cc
+++ b/nix-repl.cc
@@ -78,8 +78,6 @@ NixRepl::NixRepl(const Strings & searchPath)
     , staticEnv(false, &state.staticBaseEnv)
 {
     curDir = absPath(".");
-
-    store = openStore();
 }
 
 
@@ -622,6 +620,7 @@ int main(int argc, char * * argv)
             return true;
         });
 
+        store = openStore();
         NixRepl repl(searchPath);
         repl.mainLoop(files);
     });


### PR DESCRIPTION
`EvalState` requires the `store` global to be initialized before it is constructed
in some cases, e.g. when it needs to download a tarball for something in
`NIX_PATH`. Hence, this fixes #13.

This change will be made unnecessary once nix-repl is built against a version of Nix with [this commit](https://github.com/NixOS/nix/commit/c10c61449f954702ae6d8092120321744acd82ff) which ensures the `store` global is initialized whenever it is first used. But for now, this change fixes an existing segfault.