### PR TITLE
Add :u command which works like `nix-shell -p`.

### DIFF
--- a/nix-repl.cc
+++ b/nix-repl.cc
@@ -340,7 +340,7 @@ bool NixRepl::processLine(string line)
              << "  :r            Reload all files\n"
              << "  :s <expr>     Build dependencies of derivation, then start nix-shell\n"
              << "  :t <expr>     Describe result of evaluation\n"
-             << "  :x <expr>     Build derivation, then start nix-shell\n";
+             << "  :u <expr>     Build derivation, then start nix-shell\n";
     }
 
     else if (command == ":a" || command == ":add") {
@@ -364,7 +364,7 @@ bool NixRepl::processLine(string line)
         evalString(arg, v);
         std::cout << showType(v) << std::endl;
 
-    } else if (command == ":x") {
+    } else if (command == ":u") {
         Value v, f, result;
         evalString(arg, v);
         evalString("drv: (import <nixpkgs> {}).runCommand \"shell\" { buildInputs = [ drv ]; } \"\"", f);

--- a/nix-repl.cc
+++ b/nix-repl.cc
@@ -39,6 +39,7 @@ struct NixRepl
     void mainLoop(const Strings & files);
     void completePrefix(string prefix);
     bool getLine(string & input, const char * prompt);
+    Path getDerivationPath(Value & v);
     bool processLine(string line);
     void loadFile(const Path & path);
     void initEnv();
@@ -300,6 +301,17 @@ bool isVarName(const string & s)
 }
 
 
+Path NixRepl::getDerivationPath(Value & v) {
+    DrvInfo drvInfo(state);
+    if (!getDerivation(state, v, drvInfo, false))
+        throw Error("expression does not evaluate to a derivation, so I can't build it");
+    Path drvPath = drvInfo.queryDrvPath();
+    if (drvPath == "" || !state.store->isValidPath(drvPath))
+        throw Error("expression did not evaluate to a valid derivation");
+    return drvPath;
+}
+
+
 bool NixRepl::processLine(string line)
 {
     if (line == "") return true;
@@ -327,7 +339,8 @@ bool NixRepl::processLine(string line)
              << "  :q            Exit nix-repl\n"
              << "  :r            Reload all files\n"
              << "  :s <expr>     Build dependencies of derivation, then start nix-shell\n"
-             << "  :t <expr>     Describe result of evaluation\n";
+             << "  :t <expr>     Describe result of evaluation\n"
+             << "  :x <expr>     Build derivation, then start nix-shell\n";
     }
 
     else if (command == ":a" || command == ":add") {
@@ -350,17 +363,21 @@ bool NixRepl::processLine(string line)
         Value v;
         evalString(arg, v);
         std::cout << showType(v) << std::endl;
+
+    } else if (command == ":x") {
+        Value v, f, result;
+        evalString(arg, v);
+        evalString("drv: (import <nixpkgs> {}).runCommand \"shell\" { buildInputs = [ drv ]; } \"\"", f);
+        state.callFunction(f, v, result, Pos());
+
+        Path drvPath = getDerivationPath(result);
+        runProgram("nix-shell", Strings{drvPath});
     }
 
     else if (command == ":b" || command == ":i" || command == ":s") {
         Value v;
         evalString(arg, v);
-        DrvInfo drvInfo(state);
-        if (!getDerivation(state, v, drvInfo, false))
-            throw Error("expression does not evaluate to a derivation, so I can't build it");
-        Path drvPath = drvInfo.queryDrvPath();
-        if (drvPath == "" || !state.store->isValidPath(drvPath))
-            throw Error("expression did not evaluate to a valid derivation");
+        Path drvPath = getDerivationPath(v);
 
         if (command == ":b") {
             /* We could do the build in this process using buildPaths(),


### PR DESCRIPTION
This adds a command which works like `nix-shell -p foo` (in fact, it is implemented the same way as `-p`). The `nix-repl` equivalent would be `:u foo` assuming `foo` is an expression resulting in a derivation. Most commonly, a user would have `<nixpkgs>` loaded and do `:u packageName`.

Due to the fact that `:u foo` uses `buildInputs = [foo]`, it's also possible to use a list, e.g. `:u [vim emacs]` to enter a shell with vim and emacs present.

This also enables sessions like the following:

```
nix-repl> editors = [emacs vim]

nix-repl> :u editors

[nix-shell:~/code/nix-repl]$ which vim emacs atom
/nix/store/59rrbw4q003bl3sjrywrg4ymlx1jx3m4-vim-7.4.827/bin/vim
/nix/store/qadxydvlbpi0f7bsxgwhk4zr37gpq1qv-emacs-24.5/bin/emacs

[nix-shell:~/code/nix-repl]$ exit

nix-repl> editors = editors ++ [atom]

nix-repl> :u editors

[nix-shell:~/code/nix-repl]$ which vim emacs atom
/nix/store/59rrbw4q003bl3sjrywrg4ymlx1jx3m4-vim-7.4.827/bin/vim
/nix/store/qadxydvlbpi0f7bsxgwhk4zr37gpq1qv-emacs-24.5/bin/emacs
/nix/store/7l8q3sxjzs14k7bmy3an61hxfr03cfkh-atom-1.4.3/bin/atom

[nix-shell:~/code/nix-repl]$ exit

nix-repl>
```

EDIT: Previously named `:x` but renamed to `:u` as in "use" to be in line with the future `nix use` command.

~~I wasn't sure about the name `:x` but I consider it short for "explore". One workflow I imagined is using `:x foo` to explore new packages before trying them, and then [`:i foo`](https://github.com/edolstra/nix-repl/pull/17) to permanently install desired packages. Other obvious name choices like `:p` for `nix-shell -p` or `:s` for `nix-shell` are already taken.~~