### PR TITLE
Expand the help message printed from --help.

### DIFF
--- a/nix-repl.cc
+++ b/nix-repl.cc
@@ -59,8 +59,35 @@ struct NixRepl
 
 void printHelp()
 {
-    std::cout << "Usage: nix-repl [--help|--version]";
-    std::cout << std::endl;
+    cout << "Usage: nix-repl [--help] [--version] [-I path] paths...\n"
+         << "\n"
+         << "nix-repl is a simple read-eval-print loop (REPL) for the Nix package manager.\n"
+         << "\n"
+         << "Options:\n"
+         << "    --help\n"
+         << "        Prints out a summary of the command syntax and exits.\n"
+         << "\n"
+         << "    --version\n"
+         << "        Prints out the Nix version number on standard output and exits.\n"
+         << "\n"
+         << "    -I path\n"
+         << "        Add a path to the Nix expression search path. This option may be given\n"
+         << "        multiple times. See the NIX_PATH environment variable for information on\n"
+         << "        the semantics of the Nix search path. Paths added through -I take\n"
+         << "        precedence over NIX_PATH.\n"
+         << "\n"
+         << "    paths...\n"
+         << "        A list of paths to files containing Nix expressions which nix-repl will\n"
+         << "        load and add to its scope.\n"
+         << "\n"
+         << "        A path surrounded in < and > will be looked up in the Nix expression search\n"
+         << "        path, as in the Nix language itself.\n"
+         << "\n"
+         << "        If an element of paths starts with http:// or https://, it is interpreted\n"
+         << "        as the URL of a tarball that will be downloaded and unpacked to a temporary\n"
+         << "        location. The tarball must include a single top-level directory containing\n"
+         << "        at least a file named default.nix.\n"
+         << flush;
 }
 
 


### PR DESCRIPTION
Fixes #10. I consider this a temporary measure, however, until nix-repl has a
manpage (see #14). Then it can just open its manpage on --help like the other
nix tools do.

Much of the text in this commit was copied from nix-build's manpage.