### PR TITLE
Support multiline input by detecting "unfinished" parse errors.

### DIFF
--- a/nix-repl.cc
+++ b/nix-repl.cc
@@ -286,7 +286,7 @@ bool NixRepl::processLine(string line)
     string command, arg;
 
     if (line[0] == ':') {
-        size_t p = line.find(' ');
+        size_t p = line.find_first_of(" \n\r\t");
         command = string(line, 0, p);
         if (p != string::npos) arg = removeWhitespace(string(line, p));
     } else {

--- a/nix-repl.cc
+++ b/nix-repl.cc
@@ -99,7 +99,7 @@ void NixRepl::mainLoop(const Strings & files)
     string input;
 
     while (true) {
-        // When continuing input from a previous, don't print a prompt, just align to the same
+        // When continuing input from previous lines, don't print a prompt, just align to the same
         // number of chars as the prompt.
         const char * prompt = input.empty() ? "nix-repl> " : "          ";
         if (!getLine(input, prompt)) {


### PR DESCRIPTION
Fixes #4.

This could be made more friendly (e.g. by allowing backspacing over newlines and storing whole multiline inputs as single history items like the fish shell does) but this feels like pretty good initial support. It allows seamlessly pasting multi-line expressions or typing them by hand, and it still errors out quickly if you cause a parse error other than `unexpected $end`.

Here are some random examples:

```
nix-repl> rec {
            a = b.foo;
            b.foo.bar = 12;
          }
{ a = { ... }; b = { ... }; }

nix-repl> :p rec {
            a = b.foo;
            b.foo.bar = 12;
          }
{ a = { bar = 12; }; b = { foo = { bar = 12; }; }; }
```

(Yeah, it works with commands like `:p`, too.)