### PR TITLE
Preserve readline history across sessions. Add rl_readline_name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,7 @@ example:
 
     nix-repl> config.networking.use<TAB>
     config.networking.useDHCP   config.networking.usePredictableInterfaceNames
+
+Input history is preserved by readline in ~/.nix-repl-history
+The readline "application name" is nix-repl. This allows for nix-repl specific
+settings in ~/.inputrc

--- a/nix-repl.cc
+++ b/nix-repl.cc
@@ -20,6 +20,7 @@ using namespace nix;
 
 
 string programId = "nix-repl";
+const string historyFile = string(getenv("HOME")) + "/.nix-repl-history";
 
 
 struct NixRepl
@@ -91,8 +92,10 @@ void NixRepl::mainLoop(const Strings & files)
     reloadFiles();
     if (!loadedFiles.empty()) std::cout << std::endl;
 
+    // Allow nix-repl specific settings in .inputrc
+    rl_readline_name = "nix-repl";
     using_history();
-    read_history(0);
+    read_history(historyFile.c_str());
 
     string input;
 
@@ -649,5 +652,7 @@ int main(int argc, char * * argv)
         store = openStore();
         NixRepl repl(searchPath);
         repl.mainLoop(files);
+
+        write_history(historyFile.c_str());
     });
 }


### PR DESCRIPTION
I always prefer to have input history saved. 

This PR writes the history without any option to turn it off though [1]. If that's not wanted I can adjust the PR to include configuration through eg. a environment variable.

In addition it sets `rl_readline_name`. This is just "other" by default. Better to have a distinct name?

[1] unfortunately it doesn't seems like readline can configure these things in ~/.inputrc. I might have overlooked something though.
