### PR TITLE
When showing a lambda, also show the position of the definition

### DIFF
--- a/nix-repl.cc
+++ b/nix-repl.cc
@@ -628,7 +628,7 @@ std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int m
         break;
 
     case tLambda:
-        str << "«lambda»";
+        str << "«lambda defined at " << v.lambda.fun->pos << "»";
         break;
 
     case tPrimOp:


### PR DESCRIPTION
Example:

    > nix-repl nixpkgs
    nix-repl> lib.strict 
    «lambda defined at /home/fabian/nixpkgs/lib/debug.nix:78:12»

(instead of just «lambda») which is a lot more information :smile: 

It may be debatable if we also want this in deeper structures; evaluating `lib` gives
    
    { add = «primop»; addContextFrom = «lambda defined at /home/fabian/nixpkgs/lib/strings.nix:131:20»; addErrorContext = «primop»; addErrorContextToAttrs = «lambda defined at /home/fabian/nixpkgs/lib/attrsets.nix:164:17»; addMetaAttrs = «lambda defined at /home/fabian/nixpkgs/ ...

which might be less readable than what we had before (but I also found that not particularly readable).